### PR TITLE
Adds SteamUGC GetItemState

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -49,4 +49,5 @@ export namespace workshop {
   export function updateItem(itemId: bigint, updateDetails: UgcUpdate): Promise<UgcResult>
   export function subscribe(itemId: bigint): Promise<void>
   export function unsubscribe(itemId: bigint): Promise<void>
+  export function state(itemId: bigint): number
 }

--- a/src/workshop.rs
+++ b/src/workshop.rs
@@ -139,4 +139,14 @@ pub mod workshop {
             Err(e) => Err(Error::new(Status::GenericFailure, e.to_string())),
         }
     }
+
+    #[napi]
+    pub fn state(item_id: BigInt) -> u32 {
+        let client = crate::client::get_client();
+        let result = client
+            .ugc()
+            .item_state(PublishedFileId(item_id.get_u64().1));
+
+        result.bits()
+    }
 }


### PR DESCRIPTION
Adds SteamUGC GetItemState: https://partner.steamgames.com/doc/api/ISteamUGC#GetItemState
Returns an item state value: https://partner.steamgames.com/doc/api/ISteamUGC#EItemState

Test it by using:
```js
client.workshop.state(BigInt(id))
```

## Item State values
Specifies an items state. These are flags that can be combined. Returned by [GetItemState](https://partner.steamgames.com/doc/api/ISteamUGC#GetItemState).

Name | Value | Description
-- | -- | --
k_EItemStateNone | 0 | The item is not tracked on client.
k_EItemStateSubscribed | 1 | The current user is subscribed to this item. Not just cached.
k_EItemStateLegacyItem | 2 | The item was created with the old workshop functions in ISteamRemoteStorage.
k_EItemStateInstalled | 4 | Item is installed and usable (but maybe out of date).
k_EItemStateNeedsUpdate | 8 | The items needs an update. Either because it's not installed yet or creator updated the content.
k_EItemStateDownloading | 16 | The item update is currently downloading.
k_EItemStateDownloadPending | 32 | DownloadItem was called for this item, the content isn't available until DownloadItemResult_t is fired.