### PR TITLE
Adds SteamUGC DownloadItem and GetItemDownloadInfo

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -61,5 +61,5 @@ export namespace workshop {
   export function state(itemId: bigint): number
   export function installInfo(itemId: bigint): InstallInfo | undefined | null
   export function downloadInfo(itemId: bigint): DownloadInfo | undefined | null
-  export function download(itemId: bigint, highPriority: boolean): void
+  export function download(itemId: bigint, highPriority: boolean): boolean
 }

--- a/client.d.ts
+++ b/client.d.ts
@@ -45,15 +45,21 @@ export namespace workshop {
     contentPath?: string | undefined | null
     tags?: Array<string> | undefined | null
   }
-  export function createItem(): Promise<UgcResult>
-  export function updateItem(itemId: bigint, updateDetails: UgcUpdate): Promise<UgcResult>
-  export function subscribe(itemId: bigint): Promise<void>
-  export function unsubscribe(itemId: bigint): Promise<void>
-  export function state(itemId: bigint): number
   export interface InstallInfo {
     folder: string
     sizeOnDisk: bigint
     timestamp: number
   }
+  export interface DownloadInfo {
+    current: bigint
+    total: bigint
+  }
+  export function createItem(): Promise<UgcResult>
+  export function updateItem(itemId: bigint, updateDetails: UgcUpdate): Promise<UgcResult>
+  export function subscribe(itemId: bigint): Promise<void>
+  export function unsubscribe(itemId: bigint): Promise<void>
+  export function state(itemId: bigint): number
   export function installInfo(itemId: bigint): InstallInfo | undefined | null
+  export function downloadInfo(itemId: bigint): DownloadInfo | undefined | null
+  export function download(itemId: bigint, highPriority: boolean): void
 }

--- a/src/workshop.rs
+++ b/src/workshop.rs
@@ -206,10 +206,10 @@ pub mod workshop {
     }
 
     #[napi]
-    pub fn download(item_id: BigInt, high_priority: bool) -> () {
+    pub fn download(item_id: BigInt, high_priority: bool) -> bool {
         let client = crate::client::get_client();
         client
             .ugc()
-            .download_item(PublishedFileId(item_id.get_u64().1), high_priority);
+            .download_item(PublishedFileId(item_id.get_u64().1), high_priority)
     }
 }

--- a/src/workshop.rs
+++ b/src/workshop.rs
@@ -208,6 +208,8 @@ pub mod workshop {
     #[napi]
     pub fn download(item_id: BigInt, high_priority: bool) -> () {
         let client = crate::client::get_client();
-        client.ugc().download_item(PublishedFileId(item_id.get_u64().1), high_priority);
+        client
+            .ugc()
+            .download_item(PublishedFileId(item_id.get_u64().1), high_priority);
     }
 }

--- a/src/workshop.rs
+++ b/src/workshop.rs
@@ -30,6 +30,12 @@ pub mod workshop {
         pub timestamp: u32,
     }
 
+    #[napi(object)]
+    pub struct DownloadInfo {
+        pub current: BigInt,
+        pub total: BigInt,
+    }
+
     #[napi]
     pub async fn create_item() -> Result<UgcResult, Error> {
         let client = crate::client::get_client();
@@ -175,5 +181,33 @@ pub mod workshop {
             }),
             None => None,
         }
+    }
+
+    #[napi]
+    pub fn download_info(item_id: BigInt) -> Option<DownloadInfo> {
+        let client = crate::client::get_client();
+        let result = client
+            .ugc()
+            .item_download_info(PublishedFileId(item_id.get_u64().1));
+
+        match result {
+            Some(download_info) => Some(DownloadInfo {
+                current: BigInt {
+                    sign_bit: false,
+                    words: vec![download_info.0],
+                },
+                total: BigInt {
+                    sign_bit: false,
+                    words: vec![download_info.1],
+                },
+            }),
+            None => None,
+        }
+    }
+
+    #[napi]
+    pub fn download(item_id: BigInt, high_priority: bool) -> () {
+        let client = crate::client::get_client();
+        client.ugc().download_item(PublishedFileId(item_id.get_u64().1), high_priority);
     }
 }


### PR DESCRIPTION
Adds SteamUGC DownloadItem: https://partner.steamgames.com/doc/api/ISteamUGC#DownloadItem
Adds SteamUGC GetItemDownloadInfo: https://partner.steamgames.com/doc/api/ISteamUGC#GetItemDownloadInfo

Test it by using:
```js
// Download or update a workshop item
client.workshop.download(BigInt(workshopID))

// Start the download in high priority mode, pausing any existing in-progress Steam downloads and immediately begin downloading this workshop item
client.workshop.download(BigInt(workshopID), true)

// Get info about a pending download of a workshop item
client.workshop.downloadInfo(BigInt(workshopID))
```