### PR TITLE
More ISteamApps APIs

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -5,7 +5,25 @@ export namespace achievement {
   export function isActivated(achievement: string): boolean
 }
 export namespace apps {
+  export interface LocalSteamId {
+    steamId64: string
+    steamId32: string
+    accountId: number
+  }
   export function isSubscribedApp(appId: number): boolean
+  export function isAppInstalled(appId: number): boolean
+  export function isDlcInstalled(appId: number): boolean
+  export function isSubscribedFromFreeWeekend(): boolean
+  export function isVacBanned(): boolean
+  export function isCybercafe(): boolean
+  export function isLowViolence(): boolean
+  export function isSubscribed(): boolean
+  export function appBuildId(): number
+  export function appInstallDir(appId: number): string
+  export function appOwner(): LocalSteamId
+  export function availableGameLanguages(): Array<string>
+  export function currentGameLanguage(): string
+  export function currentBetaName(): string | null
 }
 export namespace auth {
   /** @param timeoutSeconds - The number of seconds to wait for the ticket to be validated. Default value is 10 seconds. */

--- a/client.d.ts
+++ b/client.d.ts
@@ -1,15 +1,15 @@
 export function init(appId: number): void
 export function runCallbacks(): void
+export interface PlayerSteamId {
+  steamId64: string
+  steamId32: string
+  accountId: number
+}
 export namespace achievement {
   export function activate(achievement: string): boolean
   export function isActivated(achievement: string): boolean
 }
 export namespace apps {
-  export interface LocalSteamId {
-    steamId64: string
-    steamId32: string
-    accountId: number
-  }
   export function isSubscribedApp(appId: number): boolean
   export function isAppInstalled(appId: number): boolean
   export function isDlcInstalled(appId: number): boolean
@@ -20,7 +20,7 @@ export namespace apps {
   export function isSubscribed(): boolean
   export function appBuildId(): number
   export function appInstallDir(appId: number): string
-  export function appOwner(): LocalSteamId
+  export function appOwner(): PlayerSteamId
   export function availableGameLanguages(): Array<string>
   export function currentGameLanguage(): string
   export function currentBetaName(): string | null
@@ -70,12 +70,7 @@ export namespace input {
   }
 }
 export namespace localplayer {
-  export interface LocalSteamId {
-    steamId64: string
-    steamId32: string
-    accountId: number
-  }
-  export function getSteamId(): LocalSteamId
+  export function getSteamId(): PlayerSteamId
   export function getName(): string
   export function getLevel(): number
   /** @returns the 2 digit ISO 3166-1-alpha-2 format country code which client is running in, e.g. "US" or "UK". */

--- a/src/api/apps.rs
+++ b/src/api/apps.rs
@@ -1,14 +1,10 @@
+use super::localplayer::PlayerSteamId;
 use napi_derive::napi;
 
 #[napi]
 pub mod apps {
+    use super::PlayerSteamId;
     use steamworks::AppId;
-    #[napi(object)]
-    pub struct LocalSteamId {
-        pub steam_id64: String,
-        pub steam_id32: String,
-        pub account_id: u32,
-    }
 
     #[napi]
     pub fn is_subscribed_app(app_id: u32) -> bool {
@@ -70,11 +66,11 @@ pub mod apps {
     }
 
     #[napi]
-    pub fn app_owner() -> LocalSteamId {
+    pub fn app_owner() -> PlayerSteamId {
         let client = crate::client::get_client();
         let steam_id = client.apps().app_owner();
 
-        LocalSteamId {
+        PlayerSteamId {
             steam_id64: steam_id.raw().to_string(),
             steam_id32: steam_id.steamid32(),
             account_id: steam_id.account_id().raw(),

--- a/src/api/apps.rs
+++ b/src/api/apps.rs
@@ -3,10 +3,99 @@ use napi_derive::napi;
 #[napi]
 pub mod apps {
     use steamworks::AppId;
+    #[napi(object)]
+    pub struct LocalSteamId {
+        pub steam_id64: String,
+        pub steam_id32: String,
+        pub account_id: u32,
+    }
 
     #[napi]
     pub fn is_subscribed_app(app_id: u32) -> bool {
         let client = crate::client::get_client();
         client.apps().is_subscribed_app(AppId(app_id))
+    }
+    #[napi]
+    pub fn is_app_installed(app_id: u32) -> bool {
+        let client = crate::client::get_client();
+        client.apps().is_app_installed(AppId(app_id))
+    }
+
+    #[napi]
+    pub fn is_dlc_installed(app_id: u32) -> bool {
+        let client = crate::client::get_client();
+        client.apps().is_dlc_installed(AppId(app_id))
+    }
+
+    #[napi]
+    pub fn is_subscribed_from_free_weekend() -> bool {
+        let client = crate::client::get_client();
+        client.apps().is_subscribed_from_free_weekend()
+    }
+
+    #[napi]
+    pub fn is_vac_banned() -> bool {
+        let client = crate::client::get_client();
+        client.apps().is_vac_banned()
+    }
+
+    #[napi]
+    pub fn is_cybercafe() -> bool {
+        let client = crate::client::get_client();
+        client.apps().is_cybercafe()
+    }
+
+    #[napi]
+    pub fn is_low_violence() -> bool {
+        let client = crate::client::get_client();
+        client.apps().is_low_violence()
+    }
+
+    #[napi]
+    pub fn is_subscribed() -> bool {
+        let client = crate::client::get_client();
+        client.apps().is_subscribed()
+    }
+
+    #[napi]
+    pub fn app_build_id() -> i32 {
+        let client = crate::client::get_client();
+        client.apps().app_build_id()
+    }
+
+    #[napi]
+    pub fn app_install_dir(app_id: u32) -> String {
+        let client = crate::client::get_client();
+        client.apps().app_install_dir(AppId(app_id))
+    }
+
+    #[napi]
+    pub fn app_owner() -> LocalSteamId {
+        let client = crate::client::get_client();
+        let steam_id = client.apps().app_owner();
+
+        LocalSteamId {
+            steam_id64: steam_id.raw().to_string(),
+            steam_id32: steam_id.steamid32(),
+            account_id: steam_id.account_id().raw(),
+        }
+    }
+
+    #[napi]
+    pub fn available_game_languages() -> Vec<String> {
+        let client = crate::client::get_client();
+        client.apps().available_game_languages()
+    }
+
+    #[napi]
+    pub fn current_game_language() -> String {
+        let client = crate::client::get_client();
+        client.apps().current_game_language()
+    }
+
+    #[napi]
+    pub fn current_beta_name() -> Option<String> {
+        let client = crate::client::get_client();
+        client.apps().current_beta_name()
     }
 }

--- a/src/api/localplayer.rs
+++ b/src/api/localplayer.rs
@@ -1,20 +1,22 @@
 use napi_derive::napi;
 
+#[napi(object)]
+pub struct PlayerSteamId {
+    pub steam_id64: String,
+    pub steam_id32: String,
+    pub account_id: u32,
+}
+
 #[napi]
 pub mod localplayer {
-    #[napi(object)]
-    pub struct LocalSteamId {
-        pub steam_id64: String,
-        pub steam_id32: String,
-        pub account_id: u32,
-    }
+    use super::PlayerSteamId;
 
     #[napi]
-    pub fn get_steam_id() -> LocalSteamId {
+    pub fn get_steam_id() -> PlayerSteamId {
         let client = crate::client::get_client();
         let steam_id = client.user().steam_id();
 
-        LocalSteamId {
+        PlayerSteamId {
             steam_id64: steam_id.raw().to_string(),
             steam_id32: steam_id.steamid32(),
             account_id: steam_id.account_id().raw(),


### PR DESCRIPTION
This adds all of the APIs documented in https://docs.rs/steamworks/latest/steamworks/struct.Apps.html

I wasn't really sure how to handle the `appOwner()` API, which returns a `SteamId`. `localplayer.rs` handles this by declaring a `LocalSteamId` object. I'm a Rust novice, and I couldn't figure out how or whether to share that object with `apps.rs`, so I just copied and pasted the `struct` definition for `LocalSteamId` into `apps.rs`. This works fine, but I wonder if you'd prefer to handle it differently.

Fixes #6 and #25.