### PR TITLE
Export restartAppIfNecessary on the top-level steamworks object

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports.init = (appId) => {
         }
     }
 
-    const { init: internalInit, runCallbacks, ...api } = nativeBinding
+    const { init: internalInit, runCallbacks, restartAppIfNecessary, ...api } = nativeBinding
 
     internalInit(appId)
 
@@ -50,16 +50,14 @@ module.exports.init = (appId) => {
 }
 
 /**
- * @returns {boolean}
+ * @param {number} appId - App ID of the game to load
+ * {@link https://partner.steamgames.com/doc/api/steam_api#SteamAPI_RestartAppIfNecessary}
+ * @returns {boolean} 
  */
-module.exports.restartAppIfNecessary = (appId) => {
-    const { restartAppIfNecessary: internalRestartAppIfNecessary } = nativeBinding;
-    return internalRestartAppIfNecessary(appId);
-}
+module.exports.restartAppIfNecessary = (appId) => nativeBinding.restartAppIfNecessary(appId);
 
 /**
- * Enable the steam overlay for the given electron app
- * @param {import('electron').App} app - Electron app
+ * Enable the steam overlay on electron
  * @param {boolean} [disableEachFrameInvalidation] - Should attach a single pixel to be rendered each frame
 */
 module.exports.electronEnableSteamOverlay = (disableEachFrameInvalidation) => {

--- a/index.js
+++ b/index.js
@@ -50,6 +50,14 @@ module.exports.init = (appId) => {
 }
 
 /**
+ * @returns {boolean}
+ */
+module.exports.restartAppIfNecessary = (appId) => {
+    const { restartAppIfNecessary: internalRestartAppIfNecessary } = nativeBinding;
+    return internalRestartAppIfNecessary(appId);
+}
+
+/**
  * Enable the steam overlay for the given electron app
  * @param {import('electron').App} app - Electron app
  * @param {boolean} [disableEachFrameInvalidation] - Should attach a single pixel to be rendered each frame


### PR DESCRIPTION
There's no sense in exposing it only on the client object, because you can only get a client object if you've successfully initialized.