### PR TITLE
Fix broken build.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@types/node": "*"
             },
             "devDependencies": {
-                "@napi-rs/cli": "2.15.2",
+                "@napi-rs/cli": "2.15.0",
                 "electron": "22.1.0",
                 "rimraf": "4.4.1",
                 "typescript": "4.9.5"
@@ -43,9 +43,9 @@
             }
         },
         "node_modules/@napi-rs/cli": {
-            "version": "2.15.2",
-            "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.15.2.tgz",
-            "integrity": "sha512-80tBCtCnEhAmFtB9oPM0FL74uW7fAmtpeqjvERH7Q1z/aZzCAs/iNfE7U3ehpwg9Q07Ob2Eh/+1guyCdX/p24w==",
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.15.0.tgz",
+            "integrity": "sha512-RDDr7ZF0cgbd37+NBGeQOjP7Tm/iNM+y3FmrT5bVQBXLePOTuKVC/dBsdN5UZv3Sl2XAwEvBfaGR90E0d8AA6g==",
             "dev": true,
             "bin": {
                 "napi": "scripts/index.js"
@@ -110,9 +110,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "18.11.17",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-            "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+            "version": "18.15.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+            "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
         },
         "node_modules/@types/responselike": {
             "version": "1.0.0",
@@ -257,9 +257,9 @@
             }
         },
         "node_modules/define-properties": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+            "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
             "dev": true,
             "optional": true,
             "dependencies": {
@@ -299,9 +299,9 @@
             }
         },
         "node_modules/electron/node_modules/@types/node": {
-            "version": "16.18.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.10.tgz",
-            "integrity": "sha512-XU1+v7h81p7145ddPfjv7jtWvkSilpcnON3mQ+bDi9Yuf7OI56efOglXRyXWgQ57xH3fEQgh7WOJMncRHVew5w==",
+            "version": "16.18.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+            "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==",
             "dev": true
         },
         "node_modules/end-of-stream": {
@@ -429,13 +429,13 @@
             }
         },
         "node_modules/glob": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
-            "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+            "version": "9.3.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+            "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
-                "minimatch": "^7.4.1",
+                "minimatch": "^8.0.2",
                 "minipass": "^4.2.4",
                 "path-scurry": "^1.6.1"
             },
@@ -464,10 +464,23 @@
                 "node": ">=10.0"
             }
         },
+        "node_modules/global-agent/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/global-agent/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+            "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
             "dev": true,
             "optional": true,
             "dependencies": {
@@ -522,9 +535,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/has": {
@@ -626,16 +639,12 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.0.1.tgz",
+            "integrity": "sha512-C8QsKIN1UIXeOs3iWmiZ1lQY+EnKDojWd37fXy1aSbJvH4iSma1uy2OWuoB3m4SYRli5+CUjDv3Dij5DVoetmg==",
             "dev": true,
-            "optional": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": "14 || >=16.14"
             }
         },
         "node_modules/matcher": {
@@ -661,24 +670,24 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-            "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+            "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minipass": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
-            "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -731,13 +740,13 @@
             }
         },
         "node_modules/path-scurry": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.3.tgz",
-            "integrity": "sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.4.tgz",
+            "integrity": "sha512-Qp/9IHkdNiXJ3/Kon++At2nVpnhRiPq/aSvQN+H3U1WZbvNRK0RIQK/o4HMqPoXjpuGJUEWpHSs6Mnjxqh3TQg==",
             "dev": true,
             "dependencies": {
-                "lru-cache": "^7.14.1",
-                "minipass": "^4.0.2"
+                "lru-cache": "^9.0.0",
+                "minipass": "^5.0.0"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -746,13 +755,13 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+        "node_modules/path-scurry/node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
             "dev": true,
             "engines": {
-                "node": ">=12"
+                "node": ">=8"
             }
         },
         "node_modules/pend": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ],
     "license": "MIT",
     "devDependencies": {
-        "@napi-rs/cli": "2.15.2",
+        "@napi-rs/cli": "2.15.0",
         "rimraf": "4.4.1",
         "typescript": "4.9.5",
         "electron": "22.1.0"

--- a/src/api/callback.rs
+++ b/src/api/callback.rs
@@ -3,7 +3,7 @@ use napi_derive::napi;
 #[napi]
 pub mod callback {
     use napi::{
-        bindgen_prelude::ToNapiValue,
+        bindgen_prelude::{FromNapiValue, ToNapiValue},
         threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode},
         JsFunction,
     };

--- a/src/api/matchmaking.rs
+++ b/src/api/matchmaking.rs
@@ -3,7 +3,7 @@ use napi_derive::napi;
 #[napi]
 pub mod matchmaking {
     use crate::api::localplayer::PlayerSteamId;
-    use napi::bindgen_prelude::{BigInt, Error, ToNapiValue};
+    use napi::bindgen_prelude::{BigInt, Error, FromNapiValue, ToNapiValue};
     use std::collections::HashMap;
     use steamworks::LobbyId;
     use tokio::sync::oneshot;

--- a/src/api/networking.rs
+++ b/src/api/networking.rs
@@ -3,7 +3,7 @@ use napi_derive::napi;
 #[napi]
 pub mod networking {
     use napi::{
-        bindgen_prelude::{BigInt, Buffer, ToNapiValue},
+        bindgen_prelude::{BigInt, Buffer, FromNapiValue, ToNapiValue},
         Error,
     };
     use steamworks::SteamId;


### PR DESCRIPTION
Fixes #80 and #83.

According to git bisect, the build was broken in revision f27b4a86df4569c5f87a511da2d4049f6037d20f, which added `callback.rs`.

Specifically, `callback.rs` added a `pub enum SteamCallback`. Any NAPI-RS file that exports an enum requires you to `use napi::bindgen_prelude::ToNapiValue`, which it did, but it also now requires you to use `FromNapiValue`.

~As far as I can tell, this has always been true, even back at revision f27b4a86. The parent revision to f27b4a86 deleted `Cargo.lock`, but even when I brought `Cargo.lock` back, it _still_ required `FromNapiValue`.~

~So, I have no idea why the build has been working at all for the last year, but adding `FromNapiValue` everywhere `ToNapiValue` is used definitely seems to fix it.~

EDIT: Oops, I was accidentally restoring the _wrong_ `Cargo.lock` file. Restoring the `Cargo.lock` file from 56e80a4a62eece626690eac0e91459768820665d into revision f27b4a86df4569c5f87a511da2d4049f6037d20f also fixes the build. I've filed PR #84 to bring back a `Cargo.lock` file so reproducibility issues like this don't happen in the future.

Furthermore, I've downgraded `@napi-rs/cli` to fix #83.