### PR TITLE
Restore instructions for testing Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ Make sure you have the latest [node.js](https://nodejs.org/en/), [Rust](https://
 Install dependencies with `npm install` and then run `npm run build:debug` to build the library.
 
 There is no way to build for all targets easily. The good news is that you don't need to. You can develop and test on your current target, and open a PR. When the code is merged to main, a github action will build for all targets and publish a new version.
+
+### Testing Electron
+
+Go to the [test/electron](./test/electron) directory. There, you can run `npm install` and then `npm start` to run the Electron app.
+
+Click "activate overlay" to test the overlay.


### PR DESCRIPTION
In #98 I added instructions for testing Electron; these were removed in commit 5437383b833216a3123e37316188092e5d197d7b. I assume that was an accident? Here's a PR to restore the instructions. 