### PR TITLE
Add utils.showFloatingGamepadTextInput()

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -185,6 +185,15 @@ export namespace utils {
   export function getAppId(): number
   export function getServerRealTime(): number
   export function isSteamRunningOnSteamDeck(): boolean
+  export const enum GamepadTextInputMode {
+    Normal = 0,
+    Password = 1
+  }
+  export const enum GamepadTextInputLineMode {
+    SingleLine = 0,
+    MultipleLines = 1
+  }
+  export function showGamepadTextInput(inputMode: GamepadTextInputMode, inputLineMode: GamepadTextInputLineMode, description: string, maxCharacters: number, existingText?: string | undefined | null): boolean
   export const enum FloatingGamepadTextInputMode {
     SingleLine = 0,
     MultipleLines = 1,

--- a/client.d.ts
+++ b/client.d.ts
@@ -185,6 +185,13 @@ export namespace utils {
   export function getAppId(): number
   export function getServerRealTime(): number
   export function isSteamRunningOnSteamDeck(): boolean
+  export const enum FloatingGamepadTextInputMode {
+    SingleLine = 0,
+    MultipleLines = 1,
+    Email = 2,
+    Numeric = 3
+  }
+  export function showFloatingGamepadTextInput(keyboardMode: FloatingGamepadTextInputMode, x: number, y: number, width: number, height: number): boolean
 }
 export namespace workshop {
   export interface UgcResult {

--- a/client.d.ts
+++ b/client.d.ts
@@ -193,14 +193,16 @@ export namespace utils {
     SingleLine = 0,
     MultipleLines = 1
   }
-  export function showGamepadTextInput(inputMode: GamepadTextInputMode, inputLineMode: GamepadTextInputLineMode, description: string, maxCharacters: number, existingText?: string | undefined | null): boolean
+  /** @returns the entered text, or null if cancelled or could not show the input */
+  export function showGamepadTextInput(inputMode: GamepadTextInputMode, inputLineMode: GamepadTextInputLineMode, description: string, maxCharacters: number, existingText?: string | undefined | null): Promise<string | null>
   export const enum FloatingGamepadTextInputMode {
     SingleLine = 0,
     MultipleLines = 1,
     Email = 2,
     Numeric = 3
   }
-  export function showFloatingGamepadTextInput(keyboardMode: FloatingGamepadTextInputMode, x: number, y: number, width: number, height: number): boolean
+  /** @returns true if the floating keyboard was shown, otherwise, false */
+  export function showFloatingGamepadTextInput(keyboardMode: FloatingGamepadTextInputMode, x: number, y: number, width: number, height: number): Promise<boolean>
 }
 export namespace workshop {
   export interface UgcResult {

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -2,6 +2,9 @@ use napi_derive::napi;
 
 #[napi]
 pub mod utils {
+    use napi::bindgen_prelude::{FromNapiValue, ToNapiValue};
+    use steamworks::FloatingGamepadTextInputMode as kFloatingGamepadTextInputMode;
+
     #[napi]
     pub fn get_app_id() -> u32 {
         let client = crate::client::get_client();
@@ -18,5 +21,42 @@ pub mod utils {
     pub fn is_steam_running_on_steam_deck() -> bool {
         let client = crate::client::get_client();
         client.utils().is_steam_running_on_steam_deck()
+    }
+
+    #[napi]
+    pub enum FloatingGamepadTextInputMode {
+        SingleLine,
+        MultipleLines,
+        Email,
+        Numeric,
+    }
+
+    #[napi]
+    pub fn show_floating_gamepad_text_input(
+        keyboard_mode: FloatingGamepadTextInputMode,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    ) -> bool {
+        let client = crate::client::get_client();
+        let dismissed_cb = || {};
+        client.utils().show_floating_gamepad_text_input(
+            match keyboard_mode {
+                FloatingGamepadTextInputMode::SingleLine => {
+                    kFloatingGamepadTextInputMode::SingleLine
+                }
+                FloatingGamepadTextInputMode::MultipleLines => {
+                    kFloatingGamepadTextInputMode::MultipleLines
+                }
+                FloatingGamepadTextInputMode::Email => kFloatingGamepadTextInputMode::Email,
+                FloatingGamepadTextInputMode::Numeric => kFloatingGamepadTextInputMode::Numeric,
+            },
+            x,
+            y,
+            width,
+            height,
+            dismissed_cb,
+        )
     }
 }

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -4,6 +4,8 @@ use napi_derive::napi;
 pub mod utils {
     use napi::bindgen_prelude::{FromNapiValue, ToNapiValue};
     use steamworks::FloatingGamepadTextInputMode as kFloatingGamepadTextInputMode;
+    use steamworks::GamepadTextInputLineMode as kGamepadTextInputLineMode;
+    use steamworks::GamepadTextInputMode as kGamepadTextInputMode;
 
     #[napi]
     pub fn get_app_id() -> u32 {
@@ -21,6 +23,44 @@ pub mod utils {
     pub fn is_steam_running_on_steam_deck() -> bool {
         let client = crate::client::get_client();
         client.utils().is_steam_running_on_steam_deck()
+    }
+
+    #[napi]
+    pub enum GamepadTextInputMode {
+        Normal,
+        Password,
+    }
+
+    #[napi]
+    pub enum GamepadTextInputLineMode {
+        SingleLine,
+        MultipleLines,
+    }
+
+    #[napi]
+    pub fn show_gamepad_text_input(
+        input_mode: GamepadTextInputMode,
+        input_line_mode: GamepadTextInputLineMode,
+        description: String,
+        max_characters: u32,
+        existing_text: Option<String>,
+    ) -> bool {
+        let client = crate::client::get_client();
+        let dismissed_cb = |_| {};
+        client.utils().show_gamepad_text_input(
+            match input_mode {
+                GamepadTextInputMode::Normal => kGamepadTextInputMode::Normal,
+                GamepadTextInputMode::Password => kGamepadTextInputMode::Password,
+            },
+            match input_line_mode {
+                GamepadTextInputLineMode::SingleLine => kGamepadTextInputLineMode::SingleLine,
+                GamepadTextInputLineMode::MultipleLines => kGamepadTextInputLineMode::MultipleLines,
+            },
+            &description,
+            max_characters,
+            existing_text.as_deref(),
+            dismissed_cb,
+        )
     }
 
     #[napi]


### PR DESCRIPTION
This one was pretty weird, due to the callback.

Unlike all other callbacks in `steamworks-rs`, the `show_gamepad_text_input` and `show_floating_gamepad_text_input` functions expect a `dismissed_cb` callback as an argument to the function.

https://github.com/Noxime/steamworks-rs/blob/e9cdf88f1c436871e2f72d9726da6eceac0679d4/src/utils.rs#L281

```rust
    /// Opens a floating keyboard over the game content and sends OS keyboard keys directly to the game.
    ///
    /// The text field position is specified in pixels relative the origin of the game window and is used to
    /// position the floating keyboard in a way that doesn't cover the text field.
    ///
    /// Callback is triggered when user dismisses the text input
    pub fn show_floating_gamepad_text_input<F>(
        &self,
        keyboard_mode: FloatingGamepadTextInputMode,
        x: i32,
        y: i32,
        width: i32,
        height: i32,
        mut dismissed_cb: F,
    ) -> bool
    where
        F: FnMut() + 'static + Send, // TODO: Support FnOnce callbacks
    {
        unsafe {
            register_callback(&self._inner, move |_: FloatingGamepadTextInputDismissed| {
                dismissed_cb();
            });
            sys::SteamAPI_ISteamUtils_ShowFloatingGamepadTextInput(
                self.utils,
                keyboard_mode.into(),
                x,
                y,
                width,
                height,
            )
        }
    }
```

The `FloatingGamepadTextInputDismissed` `struct` simply doesn't have `#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]` as other callback `struct`s do, so when I tried adding `FloatingGamepadTextInputDismissed` to `callback.rs` here in `steamworks.js`, the compile failed when I tried to `register_callback::<steamworks::FloatingGamepadTextInputDismissed>(threadsafe_handler)`.

I guess I could investigate fixing that as a bug in `steamworks-rs`, but I don't actually happen to need the `FloatingGamepadTextInputDismissed` callback, myself, so, in this PR, I'm just passing `show_floating_gamepad_text_input` an empty callback, just to satisfy the compiler. Presumably, if someone needs the `FloatingGamepadTextInputDismissed` callback, they can implement it themselves (perhaps adding `serde` support to `FloatingGamepadTextInputDismissed` in `steamworks-rs` first, then getting that merged, and then adding it to `callback.rs` here.