### PR TITLE
Fix MacOS builds code signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,9 @@ jobs:
               uses: dtolnay/rust-toolchain@stable
               with:
                   toolchain: stable
-                  targets: x86_64-pc-windows-msvc, x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin
+                  targets: x86_64-pc-windows-msvc, x86_64-unknown-linux-gnu
 
             - uses: Swatinem/rust-cache@v2
-
-            - name: Install ziglang
-              uses: goto-bus-stop/setup-zig@v2
 
             - run: cargo install cargo-xwin
 
@@ -42,12 +39,6 @@ jobs:
 
             - name: Node install
               run: npm ci
-
-            - name: Build Mac x64
-              run: npm run build -- --zig --target x86_64-apple-darwin
-
-            - name: Build Mac arm64
-              run: npm run build -- --zig --target aarch64-apple-darwin
 
             - name: Build Linux
               run: npm run build -- --target x86_64-unknown-linux-gnu
@@ -62,12 +53,52 @@ jobs:
                   path: dist
                   if-no-files-found: error
 
+    build-mac:
+        runs-on: macos-latest
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
+
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: stable
+                  targets: x86_64-apple-darwin, aarch64-apple-darwin
+
+            - uses: Swatinem/rust-cache@v2
+
+            - run: cargo install cargo-xwin
+
+            - name: Clippy
+              run: cargo clippy
+
+            - name: Node install
+              run: npm ci
+
+            - name: Build Mac x64
+              run: npm run build -- --target x86_64-apple-darwin
+
+            - name: Build Mac arm64
+              run: npm run build -- --target aarch64-apple-darwin
+
+            - name: Upload artifact
+              uses: actions/upload-artifact@v3
+              with:
+                  name: OS specific binaries
+                  path: dist
+                  if-no-files-found: error
+
     deploy:
         # prevents this action from running on forks or pull requests
         if: ${{ github.repository == 'ceifa/steamworks.js' && github.event_name == 'push' }}
 
         runs-on: ubuntu-latest
-        needs: build
+        needs: [build, build-mac]
 
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
Mac OS builds linked with zig are improperly output, making them impossible to sign & notarize, thus making it difficult to use in professional electron apps/games. 

This goes back to building MacOS builds on MacOS with XCode's linker to produce correct build outputs.

Fixes #103 