### PR TITLE
upgrade to track most recent version of steamworks-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,8 +334,9 @@ dependencies = [
 
 [[package]]
 name = "steamworks"
-version = "0.10.0"
-source = "git+https://github.com/Noxime/steamworks-rs.git?rev=f00f30954eaadb96e54b23fb8216649ed53a663f#f00f30954eaadb96e54b23fb8216649ed53a663f"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79d6f059322f73a4586cc2d0ca595ce1583104b2b1574ae1bb87f2c05bf4c67"
 dependencies = [
  "bitflags 1.3.2",
  "lazy_static",
@@ -346,8 +347,9 @@ dependencies = [
 
 [[package]]
 name = "steamworks-sys"
-version = "0.10.0"
-source = "git+https://github.com/Noxime/steamworks-rs.git?rev=f00f30954eaadb96e54b23fb8216649ed53a663f#f00f30954eaadb96e54b23fb8216649ed53a663f"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef6b00f8fe8eaaaff22cb9b70822a48c1a5d772bc682c202a57c0b438175845"
 
 [[package]]
 name = "steamworksjs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,7 @@ napi = { version = "2.13.1", features = ["tokio_rt", "napi6", "serde-json"] }
 napi-derive = "2.13.0"
 lazy_static = "1"
 tokio = { version = "1", features = ["sync", "time"] }
-steamworks = { git = "https://github.com/Noxime/steamworks-rs.git", rev = "f00f30954eaadb96e54b23fb8216649ed53a663f", features = [
-    "serde",
-] }
+steamworks = { version="0.11.0", features = [ "serde", ] }
 serde = "1"
 serde_json = "1"
 

--- a/src/api/workshop.rs
+++ b/src/api/workshop.rs
@@ -67,7 +67,7 @@ pub mod workshop {
             }
 
             if let Some(tags) = self.tags {
-                update = update.tags(tags);
+                update = update.tags(tags, false);
             }
 
             if let Some(content_path) = self.content_path {


### PR DESCRIPTION
only change required was setting `allow_admin_tags` to `false`. I can't find any documentation for what this field does, and it doesn't seem likely that this library would want to set admin tags anyway