### PR TITLE
API: Get achievements

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -26,6 +26,7 @@ export declare namespace apps {
   export function availableGameLanguages(): Array<string>
   export function currentGameLanguage(): string
   export function currentBetaName(): string | null
+  export function achievements(): Array<string>
 }
 export declare namespace auth {
   /**

--- a/client.d.ts
+++ b/client.d.ts
@@ -10,6 +10,7 @@ export declare namespace achievement {
   export function activate(achievement: string): boolean
   export function isActivated(achievement: string): boolean
   export function clear(achievement: string): boolean
+  export function names(): Array<string>
 }
 export declare namespace apps {
   export function isSubscribedApp(appId: number): boolean
@@ -26,7 +27,6 @@ export declare namespace apps {
   export function availableGameLanguages(): Array<string>
   export function currentGameLanguage(): string
   export function currentBetaName(): string | null
-  export function achievements(): Array<string>
 }
 export declare namespace auth {
   /**

--- a/src/api/achievement.rs
+++ b/src/api/achievement.rs
@@ -33,4 +33,13 @@ pub mod achievement {
             .and_then(|_| client.user_stats().store_stats())
             .is_ok()
     }
+
+    #[napi]
+    pub fn names() -> Vec<String> {
+        let client = crate::client::get_client();
+        client
+            .user_stats()
+            .get_achievement_names()
+            .expect("Failed to get achievement names")
+    }
 }

--- a/src/api/apps.rs
+++ b/src/api/apps.rs
@@ -89,4 +89,13 @@ pub mod apps {
         let client = crate::client::get_client();
         client.apps().current_beta_name()
     }
+
+    #[napi]
+    pub fn achievements() -> Vec<String> {
+        let client = crate::client::get_client();
+        client
+            .user_stats()
+            .get_achievement_names()
+            .expect("Failed to get achievement names")
+    }
 }

--- a/src/api/apps.rs
+++ b/src/api/apps.rs
@@ -89,13 +89,4 @@ pub mod apps {
         let client = crate::client::get_client();
         client.apps().current_beta_name()
     }
-
-    #[napi]
-    pub fn achievements() -> Vec<String> {
-        let client = crate::client::get_client();
-        client
-            .user_stats()
-            .get_achievement_names()
-            .expect("Failed to get achievement names")
-    }
 }


### PR DESCRIPTION
This PR adds a new API to get names of all achievements in the current app. I used the example at https://github.com/Noxime/steamworks-rs/tree/master/examples/achievements#get_achievement_names.