### PR TITLE
Made build action use an older ubuntu machine to prevent glibc versions issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
     check:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         steps:
             - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
               run: cargo clippy
 
     build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
I was trying to use this library to integrate my electron game with steam and only version 0.1.0 was working with the glibc version in my machine.

The PR fixes the issue https://github.com/ceifa/steamworks.js/issues/122 by using an older machine to generate the shared libraries.

I tested on my fork and the build works without issue.