### PR TITLE
migrate dependency of GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: OS specific binaries
+                  name: Binary (Windows / Linux)
                   path: dist
                   if-no-files-found: error
 
@@ -95,7 +95,7 @@ jobs:
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: OS specific binaries
+                  name: Binary (MacOS x64 / arm64)
                   path: dist
                   if-no-files-found: error
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: Binary (Windows / Linux)
+                  name: Binary (Windows, Linux)
                   path: dist
                   if-no-files-found: error
 
@@ -95,7 +95,7 @@ jobs:
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: Binary (MacOS x64 / arm64)
+                  name: Binary (MacOS x64, arm64)
                   path: dist
                   if-no-files-found: error
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Rust
               uses: dtolnay/rust-toolchain@stable
@@ -31,7 +31,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Node
               uses: actions/setup-node@v3
@@ -58,7 +58,7 @@ jobs:
               run: npm run build -- --target x86_64-pc-windows-msvc
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: OS specific binaries
                   path: dist
@@ -68,7 +68,7 @@ jobs:
         runs-on: macos-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Node
               uses: actions/setup-node@v3
@@ -93,7 +93,7 @@ jobs:
               run: npm run build -- --target aarch64-apple-darwin
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: OS specific binaries
                   path: dist

--- a/.github/workflows/typescript-smoke-test.yml
+++ b/.github/workflows/typescript-smoke-test.yml
@@ -5,7 +5,7 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Node.js
               uses: actions/setup-node@v3


### PR DESCRIPTION
* Migrated `actions/upload-artifact@v3` to `v4` because `v3` is deprecated.
* Fixed name of artifacts
  * https://github.com/actions/upload-artifact#breaking-changes
* Migrated `actions/checkout@v3`  to `v4`
  * Not necessary but did while I'm at it

It'll resolve workflow failures.
https://github.com/orgs/community/discussions/152695

FYI: [Tested in forked repo](https://github.com/potdig/steamworks.js/actions/runs/13994699330/job/39186822312)