### PR TITLE
CI: Upgrade GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ env:
 
 jobs:
     check:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Rust
               uses: dtolnay/rust-toolchain@stable
@@ -28,15 +28,15 @@ jobs:
               run: cargo clippy
 
     build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: 18.x
+                  node-version: 22.x
 
             - name: Setup Rust
               uses: dtolnay/rust-toolchain@stable
@@ -58,9 +58,9 @@ jobs:
               run: npm run build -- --target x86_64-pc-windows-msvc
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
-                  name: OS specific binaries
+                  name: binaries-windows-linux
                   path: dist
                   if-no-files-found: error
 
@@ -68,12 +68,12 @@ jobs:
         runs-on: macos-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: 18.x
+                  node-version: 22.x
 
             - name: Setup Rust
               uses: dtolnay/rust-toolchain@stable
@@ -93,9 +93,9 @@ jobs:
               run: npm run build -- --target aarch64-apple-darwin
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
-                  name: OS specific binaries
+                  name: binaries-macos
                   path: dist
                   if-no-files-found: error
 
@@ -107,13 +107,14 @@ jobs:
         needs: [build, build-mac]
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Download build
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
-                  name: OS specific binaries
                   path: dist/
+                  pattern: binaries-*
+                  merge-multiple: true
 
             - name: Log files
               run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
     check:
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-22.04
 
         steps:
             - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
               run: cargo clippy
 
     build:
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-22.04
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
     check:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
 
         steps:
             - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
               run: cargo clippy
 
     build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
     check:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
 
         steps:
             - uses: actions/checkout@v4
@@ -28,7 +28,11 @@ jobs:
               run: cargo clippy
 
     build:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
+
+        # Run in ubuntu:20.04 container to avoid the issue with glibc version
+        container:
+            image: ubuntu:20.04
 
         steps:
             - uses: actions/checkout@v4
@@ -37,6 +41,9 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 22.x
+
+            # ubuntu:20.04 does not have curl and gcc/g++ installed by default
+            - run: apt-get update && apt-get install -y curl build-essential
 
             - name: Setup Rust
               uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
     check:
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-20.04
 
         steps:
             - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
               run: cargo clippy
 
     build:
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-20.04
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/typescript-smoke-test.yml
+++ b/.github/workflows/typescript-smoke-test.yml
@@ -5,12 +5,12 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: 18.x
+                  node-version: 22.x
 
             - name: Install NPM dependencies
               run: npm install && cd test/typescript && npm install


### PR DESCRIPTION
Due to the recent deprecation of artifact actions (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), merging PRs does not trigger the deploy to npm. #181 tries to update the workflow, but it does not update the relevant config of the last action using `actions/download-artifact`.

This PR updates all actions, including artifact actions. You can verify it by checking the sample workflow at https://github.com/catloversg/steamworks.js/actions/workflows/test-workflow.yml.