### PR TITLE
Add isOverlayEnabled

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
               uses: dtolnay/rust-toolchain@stable
               with:
                   toolchain: stable
+          
+            - name: Install rustfmt
+              run: rustup component add rustfmt
 
             - name: Check formatting
               run: cargo fmt --all --check

--- a/client.d.ts
+++ b/client.d.ts
@@ -220,6 +220,7 @@ export declare namespace utils {
   export function getAppId(): number
   export function getServerRealTime(): number
   export function isSteamRunningOnSteamDeck(): boolean
+  export function isOverlayEnabled(): boolean
   export const enum GamepadTextInputMode {
     Normal = 0,
     Password = 1

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -26,6 +26,12 @@ pub mod utils {
     }
 
     #[napi]
+    pub fn is_overlay_enabled() -> bool {
+        let client = crate::client::get_client();
+        client.utils().is_overlay_enabled()
+    }
+
+    #[napi]
     pub enum GamepadTextInputMode {
         Normal,
         Password,


### PR DESCRIPTION
Checks if the Steam Overlay is running & the user can access it.

Very usefull function to actually check that the overlay is enabled and working, as there are cases where a user may have disabled the overlay manually or platform does not support it / is bugged. (Electron + Mac for example)

This function would make it so that people can implement messaging to the user that the overlay is missing.