### PR TITLE
Feat: Detect Steam overlay availability

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -1,6 +1,7 @@
 export declare function init(appId?: number | undefined | null): void
 export declare function restartAppIfNecessary(appId: number): boolean
 export declare function runCallbacks(): void
+export declare function isOverlayEnabled(): boolean
 export interface PlayerSteamId {
   steamId64: bigint
   steamId32: string
@@ -336,6 +337,7 @@ export declare namespace workshop {
    * @returns an array of subscribed workshop item ids
    */
   export function getSubscribedItems(): Array<bigint>
+  export function deleteItem(itemId: bigint): Promise<void>
   export const enum UGCQueryType {
     RankedByVote = 0,
     RankedByPublicationDate = 1,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 export function init(appId?: number): Omit<Client, "init" | "runCallbacks">;
 export function restartAppIfNecessary(appId: number): boolean;
 export function electronEnableSteamOverlay(disableEachFrameInvalidation?: boolean): void;
+export function isOverlayEnabled(): boolean;
 export type Client = typeof import("./client.d");
 export const SteamCallback: typeof import("./client.d").callback.SteamCallback;

--- a/index.js
+++ b/index.js
@@ -73,5 +73,7 @@ module.exports.electronEnableSteamOverlay = (disableEachFrameInvalidation) => {
     }
 }
 
+module.exports.isOverlayEnabled = nativeBinding.isOverlayEnabled;
+
 const SteamCallback = nativeBinding.callback.SteamCallback
 module.exports.SteamCallback = SteamCallback

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,3 +23,7 @@ pub fn drop_client() {
     let mut client_ref = STEAM_CLIENT.lock().unwrap();
     *client_ref = None;
 }
+
+pub fn is_overlay_enabled() -> bool {
+    get_client().utils().is_overlay_enabled()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,4 +40,9 @@ pub fn run_callbacks() {
     client::get_client().run_callbacks();
 }
 
+#[napi]
+pub fn is_overlay_enabled() -> bool {
+    client::is_overlay_enabled()
+}
+
 pub mod api;


### PR DESCRIPTION
I've got this to work using these few small changes.

On my electron app I used something like

```
let steamInitialized = false;
let steamOverlayEnabled = null;

try {
    console.log("Initializing Steam with app ID: XXX");
    const steamworks = require('steamworks.js');
    global.steamClient = steamworks.init(XXX);
    require('steamworks.js').electronEnableSteamOverlay();
    console.log("Steam initialized successfully");

    setTimeout(() => {
        try {
            const overlayEnabled = steamworks.isOverlayEnabled();
            steamOverlayEnabled = overlayEnabled;
            console.log('Steam overlay enabled (delayed):', overlayEnabled);
        } catch (e) {
            console.error('Failed to query overlay status:', e);
        }
    }, 3000);

    steamInitialized = true;
} catch (e) {
    console.error("Failed to initialize Steam:", e.message);
    steamInitialized = false;
}
```
  
  Key was waiting - in this example 3 seconds - before checking enabled status.