### PR TITLE
API: Check if a file is persisted in the Steam Cloud and get file timestamp

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -71,6 +71,8 @@ export declare namespace cloud {
   export function writeFile(name: string, content: string): boolean
   export function deleteFile(name: string): boolean
   export function fileExists(name: string): boolean
+  export function isFilePersisted(name: string): boolean
+  export function fileTimestamp(name: string): number
   export function listFiles(): Array<FileInfo>
   export class FileInfo {
     name: string
@@ -336,6 +338,7 @@ export declare namespace workshop {
    * @returns an array of subscribed workshop item ids
    */
   export function getSubscribedItems(): Array<bigint>
+  export function deleteItem(itemId: bigint): Promise<void>
   export const enum UGCQueryType {
     RankedByVote = 0,
     RankedByPublicationDate = 1,

--- a/src/api/cloud.rs
+++ b/src/api/cloud.rs
@@ -72,6 +72,22 @@ pub mod cloud {
     }
 
     #[napi]
+    pub fn is_file_persisted(name: String) -> bool {
+        let client = crate::client::get_client();
+        let file = client.remote_storage().file(&name);
+
+        file.is_persisted()
+    }
+
+    #[napi]
+    pub fn file_timestamp(name: String) -> i64 {
+        let client = crate::client::get_client();
+        let file = client.remote_storage().file(&name);
+
+        file.timestamp()
+    }
+
+    #[napi]
     pub fn list_files() -> Vec<FileInfo> {
         let client = crate::client::get_client();
         client

--- a/src/api/workshop.rs
+++ b/src/api/workshop.rs
@@ -410,13 +410,13 @@ pub mod workshop {
     pub async fn delete_item(item_id: BigInt) -> Result<(), Error> {
         let client = crate::client::get_client();
         let (tx, rx) = oneshot::channel();
-    
+
         client
             .ugc()
             .delete_item(PublishedFileId(item_id.get_u64().1), |result| {
                 tx.send(result).unwrap();
             });
-    
+
         let result = rx.await.unwrap();
         match result {
             Ok(()) => Ok(()),


### PR DESCRIPTION
This PR exposes `is_persisted()` and `timestamp()` of `SteamFile` through new JS APIs.

The unrelated changes were added by `npm run format` and `npm run types`. They are missing changes from #172.